### PR TITLE
Add async/await methods to APIClient

### DIFF
--- a/.github/workflows/publich_podspec.yml
+++ b/.github/workflows/publich_podspec.yml
@@ -3,14 +3,14 @@ on: [workflow_dispatch]
 jobs:
 
   publish:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: '13.0'
 
     - name: Publish Adyen.podspec
       run: |

--- a/.github/workflows/test-SPM-integration.yml
+++ b/.github/workflows/test-SPM-integration.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   SPM:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: n1hility/cancel-previous-runs@v2
@@ -22,8 +22,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
-
+        xcode-version: '13.0'
     - name: Resolve dependencies
       run: |
         brew update

--- a/.github/workflows/test-SPM-integration.yml
+++ b/.github/workflows/test-SPM-integration.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.0'
+        xcode-version: latest-stable
     - name: Resolve dependencies
       run: |
         brew update

--- a/.github/workflows/test-carthage-integration.yml
+++ b/.github/workflows/test-carthage-integration.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   carthage:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: n1hility/cancel-previous-runs@v2
@@ -22,8 +22,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
-
+        xcode-version: '13.0'
     - name: Resolve dependencies
       run: |
         brew update

--- a/.github/workflows/test-carthage-integration.yml
+++ b/.github/workflows/test-carthage-integration.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.0'
+        xcode-version: latest-stable
     - name: Resolve dependencies
       run: |
         brew update

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.0'
+        xcode-version: latest-stable
     - name: Test Cocoapods Integration
       run: |
         gem install cocoapods

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   pods:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: n1hility/cancel-previous-runs@v2
@@ -22,8 +22,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
-
+        xcode-version: '13.0'
     - name: Test Cocoapods Integration
       run: |
         gem install cocoapods

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -8,6 +8,18 @@ import Foundation
 import UIKit
 
 /// :nodoc:
+/// Describes possible `APIClient` errors
+public enum APIClientError: LocalizedError {
+    
+    case invalidResponse
+    
+    var errorDescription: String {
+        return "Invalid Response"
+    }
+    
+}
+
+/// :nodoc:
 /// Describes any API Client.
 public protocol APIClientProtocol: AnyObject {
     
@@ -65,11 +77,11 @@ public final class APIClient: APIClientProtocol {
         do {
             let result = try await urlSession.data(for: try buildUrlRequest(from: request))
             
-            guard let httpResponse = result.1 as? HTTPURLResponse else {
-                fatalError("Invalid response.")
+            if let httpResponse = result.1 as? HTTPURLResponse {
+                return Self.handle(.success(.init(data: result.0, response: httpResponse)), request)
+            } else {
+                return .failure(APIClientError.invalidResponse)
             }
-            
-            return Self.handle(.success(.init(data: result.0, response: httpResponse)), request)
         } catch {
             return .failure(error)
         }

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -75,10 +75,11 @@ public final class APIClient: APIClientProtocol {
     @available(iOS 15.0.0, *)
     public func perform<R: Request>(_ request: R) async -> Result<R.ResponseType, Error> {
         do {
-            let result = try await urlSession.data(for: try buildUrlRequest(from: request))
+            let result = try await urlSession
+                .data(for: try buildUrlRequest(from: request)) as (data: Data, response: URLResponse)
             
-            if let httpResponse = result.1 as? HTTPURLResponse {
-                return Self.handle(.success(.init(data: result.0, response: httpResponse)), request)
+            if let httpResponse = result.response as? HTTPURLResponse {
+                return Self.handle(.success(.init(data: result.data, response: httpResponse)), request)
             } else {
                 return .failure(APIClientError.invalidResponse)
             }

--- a/AdyenNetworking/Helpers/URLSessionHelpers.swift
+++ b/AdyenNetworking/Helpers/URLSessionHelpers.swift
@@ -26,7 +26,7 @@ internal extension URLSession {
             } else if let data = data, let response = response as? HTTPURLResponse {
                 completion(.success(URLSessionSuccess(data: data, response: response)))
             } else {
-                fatalError("Invalid response.")
+                completion(.failure(APIClientError.invalidResponse))
             }
         }
     }

--- a/AdyenNetworking/Helpers/URLSessionHelpers.swift
+++ b/AdyenNetworking/Helpers/URLSessionHelpers.swift
@@ -14,35 +14,21 @@ internal struct URLSessionSuccess {
 
 /// :nodoc:
 internal extension URLSession {
-    /// :nodoc:
-    func dataTask(with url: URL, completion: @escaping ((Result<URLSessionSuccess, Error>) -> Void)) -> URLSessionDataTask {
-        dataTask(with: url, completionHandler: { data, response, error in
-            self.handle(data: data, response: response, error: error, completion: completion)
-        })
-    }
 
     /// :nodoc:
-    func dataTask(with urlRequest: URLRequest, completion: @escaping ((Result<URLSessionSuccess, Error>) -> Void)) -> URLSessionDataTask {
-        dataTask(with: urlRequest, completionHandler: { data, response, error in
-            self.handle(data: data, response: response, error: error, completion: completion)
-        })
-    }
-
-    /// :nodoc:
-    private func handle(data: Data?, response: URLResponse?, error: Error?, completion: @escaping ((Result<URLSessionSuccess, Error>) -> Void)) {
-        let httpResponse = response as? HTTPURLResponse
-        if let headers = httpResponse?.allHeaderFields,
-           let path = response?.url?.path {
-            adyenPrint("---- Response Headers (/\(path)) ----")
-            adyenPrint(headers)
-        }
-
-        if let error = error {
-            completion(.failure(error))
-        } else if let data = data, let response = response as? HTTPURLResponse {
-            completion(.success(URLSessionSuccess(data: data, response: response)))
-        } else {
-            fatalError("Invalid response.")
+    func dataTask(
+        with urlRequest: URLRequest,
+        completion: @escaping ((Result<URLSessionSuccess, Error>) -> Void)
+    ) -> URLSessionDataTask {
+        dataTask(with: urlRequest) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let data = data, let response = response as? HTTPURLResponse {
+                completion(.success(URLSessionSuccess(data: data, response: response)))
+            } else {
+                fatalError("Invalid response.")
+            }
         }
     }
+    
 }

--- a/Networking Demo AppTests/APIClientTests.swift
+++ b/Networking Demo AppTests/APIClientTests.swift
@@ -80,8 +80,6 @@ class APIClientTests: XCTestCase {
     
     @available(iOS 15.0.0, *)
     func testAsyncValidCreateRequest() async throws {
-        let apiClientExpectation = expectation(description: "expect apiClient call back to be called.")
-        
         let name = UUID().uuidString
         let newUser = UserModel(id: Int.random(in: 0...1000),
                                 name: name,
@@ -91,27 +89,21 @@ class APIClientTests: XCTestCase {
         let validCreateRequest = CreateUsersRequest(userModel: newUser)
         switch await apiClient.perform(validCreateRequest) {
         case .success:
-            apiClientExpectation.fulfill()
+            break
         case .failure:
             XCTFail()
         }
-        
-        await waitForExpectations(timeout: 10, handler: nil)
     }
     
     @available(iOS 15.0.0, *)
     func testAsyncInvalidCreateRequest() async throws {
-        let apiClientExpectation = expectation(description: "expect apiClient call back to be called.")
         let invalidCreateRequest = InvalidCreateUsersRequest()
         switch await apiClient.perform(invalidCreateRequest) {
         case .success:
             XCTFail()
         case .failure(let error):
             XCTAssertTrue(error is CreateUsersErrorResponse)
-            apiClientExpectation.fulfill()
         }
-
-        await waitForExpectations(timeout: 10, handler: nil)
     }
 
 }

--- a/Networking Demo AppTests/APIClientTests.swift
+++ b/Networking Demo AppTests/APIClientTests.swift
@@ -77,5 +77,41 @@ class APIClientTests: XCTestCase {
         }
         waitForExpectations(timeout: 10, handler: nil)
     }
+    
+    @available(iOS 15.0.0, *)
+    func testAsyncValidCreateRequest() async throws {
+        let apiClientExpectation = expectation(description: "expect apiClient call back to be called.")
+        
+        let name = UUID().uuidString
+        let newUser = UserModel(id: Int.random(in: 0...1000),
+                                name: name,
+                                email: "\(name)@gmail.com",
+                                gender: .female,
+                                status: .active)
+        let validCreateRequest = CreateUsersRequest(userModel: newUser)
+        switch await apiClient.perform(validCreateRequest) {
+        case .success:
+            apiClientExpectation.fulfill()
+        case .failure:
+            XCTFail()
+        }
+        
+        await waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    @available(iOS 15.0.0, *)
+    func testAsyncInvalidCreateRequest() async throws {
+        let apiClientExpectation = expectation(description: "expect apiClient call back to be called.")
+        let invalidCreateRequest = InvalidCreateUsersRequest()
+        switch await apiClient.perform(invalidCreateRequest) {
+        case .success:
+            XCTFail()
+        case .failure(let error):
+            XCTAssertTrue(error is CreateUsersErrorResponse)
+            apiClientExpectation.fulfill()
+        }
+
+        await waitForExpectations(timeout: 10, handler: nil)
+    }
 
 }


### PR DESCRIPTION
This PR adds async/await methods to APIClient.
also removes `networkActivityIndicatorVisible` functionality