### PR TITLE
Logging Improvements

### DIFF
--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -162,9 +162,9 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
     }
     
     private static func log<R: Request>(result: URLSessionSuccess, request: R) {
-        if let path = result.response.url?.path {
-            adyenPrint("---- Response Headers (/\(path)) ----")
-            adyenPrint(result.response.allHeaderFields)
+        if let headers = result.response.allHeaderFields as? [String: String] {
+            adyenPrint("---- Response Headers (/\(request.path)) ----")
+            adyenPrint(headers)
         }
         
         adyenPrint("---- Response (/\(request.path)) ----")

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -162,6 +162,9 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
     }
     
     private static func log<R: Request>(result: URLSessionSuccess, request: R) {
+        adyenPrint("---- Response Code (/\(request.path)) ----")
+        adyenPrint(result.response.statusCode)
+        
         if let headers = result.response.allHeaderFields as? [String: String] {
             adyenPrint("---- Response Headers (/\(request.path)) ----")
             adyenPrint(headers)


### PR DESCRIPTION
This PR improves the logging of the responses. Adds logging of the response code and removes `AnyHashable` when printing response headers.
Before
```
---- Response Headers (//foo/bar/baz) ----
[AnyHashable("Date"): Tue, 01 Feb 2022 12:44:43 GMT, AnyHashable("Keep-Alive"): timeout=15, max=100, AnyHashable("Content-Encoding"): gzip, AnyHashable("Server"): Apache, AnyHashable("Transfer-Encoding"): Identity, AnyHashable("Content-Type"): application/json;charset=utf-8, AnyHashable("Vary"): Accept-Encoding, AnyHashable("Connection"): Keep-Alive, AnyHashable("Set-Cookie"): JSESSIONID=1234567.foobar; Path=/foobar; Secure; HttpOnly]
```
After
```
---- Response Code (/bar/baz) ----
200
---- Response Headers (/bar/baz) ----
["Server": "Apache", "Vary": "Accept-Encoding", "Date": "Tue, 01 Feb 2022 13:09:12 GMT", "Keep-Alive": "timeout=15, max=100", "Transfer-Encoding": "Identity", "Content-Type": "application/json;charset=utf-8", "Content-Encoding": "gzip", "Set-Cookie": "JSESSIONID=1234567.foobar; Path=/foobar; Secure; HttpOnly", "Connection": "Keep-Alive"]
```