### PR TITLE
fix: add control for empty response body

### DIFF
--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -133,11 +133,19 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
     ) throws -> HTTPResponse<R.ResponseType> {
         log(result: result, request: request)
         do {
-            return HTTPResponse(
-                headers: result.headers,
-                statusCode: result.statusCode,
-                responseBody: try Coder.decode(result.data) as R.ResponseType
-            )
+            if result.data.isEmpty, let emptyResponse = EmptyResponse() as? R.ResponseType {
+                return HTTPResponse(
+                    headers: result.headers,
+                    statusCode: result.statusCode,
+                    responseBody: emptyResponse
+                )
+            } else {
+                return HTTPResponse(
+                    headers: result.headers,
+                    statusCode: result.statusCode,
+                    responseBody: try Coder.decode(result.data) as R.ResponseType
+                )
+            }
         } catch {
             if let errorResponse: R.ErrorResponseType = try? Coder.decode(result.data) {
                 throw HTTPErrorResponse(

--- a/AdyenNetworking/APIClient/Request.swift
+++ b/AdyenNetworking/APIClient/Request.swift
@@ -61,6 +61,9 @@ public protocol Request: Encodable {
 /// Represents an API response.
 public protocol Response: Decodable { }
 
+/// Represents an empty API response.
+public struct EmptyResponse: Response {}
+
 /// Represents an API Error response.
 public protocol ErrorResponse: Response, Error { }
 


### PR DESCRIPTION
## Summary
If the request is completed successfully but there is no response body, parsing error is thrown as a result. This leads failure handler to be triggered instead of success handler.
This fix solves the problem by providing an empty response object when response body is empty. 

## Tested scenarios
There was no endpoint which returns an empty response body found and therefore no test case was added.  
