### PR TITLE
fix: add public initializer

### DIFF
--- a/AdyenNetworking/APIClient/Request.swift
+++ b/AdyenNetworking/APIClient/Request.swift
@@ -62,7 +62,10 @@ public protocol Request: Encodable {
 public protocol Response: Decodable { }
 
 /// Represents an empty API response.
-public struct EmptyResponse: Response {}
+public struct EmptyResponse: Response {
+    
+    public init() { }
+}
 
 /// Represents an API Error response.
 public protocol ErrorResponse: Response, Error { }


### PR DESCRIPTION
EmptyResponse should be allowed to be created in the modules/projects that import adyen-networking-ios. One example scenario is where we create a test case.
Currently, we are not able to create an instance since memberwise initializer of a struct has internal access level.

