### PR TITLE
Add AnyCoder protocol to enable custom encoding and decoding

### DIFF
--- a/AdyenNetworking.xcodeproj/project.pbxproj
+++ b/AdyenNetworking.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5A2AEC7327B1A871004694C9 /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2AEC7227B1A871004694C9 /* HTTPResponse.swift */; };
+		B14E1D8F28A27F1D00E36290 /* AnyCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14E1D8E28A27F1D00E36290 /* AnyCoder.swift */; };
 		F913B3AD26B1854F008F6CD2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913B3AC26B1854F008F6CD2 /* AppDelegate.swift */; };
 		F913B3AF26B1854F008F6CD2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913B3AE26B1854F008F6CD2 /* SceneDelegate.swift */; };
 		F913B3B126B1854F008F6CD2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913B3B026B1854F008F6CD2 /* ViewController.swift */; };
@@ -82,6 +83,7 @@
 
 /* Begin PBXFileReference section */
 		5A2AEC7227B1A871004694C9 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
+		B14E1D8E28A27F1D00E36290 /* AnyCoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCoder.swift; sourceTree = "<group>"; };
 		F913B3AA26B1854F008F6CD2 /* Networking Demo App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Networking Demo App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F913B3AC26B1854F008F6CD2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F913B3AE26B1854F008F6CD2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 		F938998826B0056A0065561F /* APIClient */ = {
 			isa = PBXGroup;
 			children = (
+				B14E1D8E28A27F1D00E36290 /* AnyCoder.swift */,
 				F938999926B005D70065561F /* AnyAPIContext.swift */,
 				F938999A26B005D70065561F /* AnyAPIEnvironment.swift */,
 				F938999726B005B00065561F /* Request.swift */,
@@ -493,6 +496,7 @@
 				F93899A226B006610065561F /* URLSessionHelpers.swift in Sources */,
 				F938999426B0059E0065561F /* RetryOnErrorAPIClient.swift in Sources */,
 				F93899AA26B008080065561F /* URLHelpers.swift in Sources */,
+				B14E1D8F28A27F1D00E36290 /* AnyCoder.swift in Sources */,
 				F93899A526B006900065561F /* Logging.swift in Sources */,
 				5A2AEC7327B1A871004694C9 /* HTTPResponse.swift in Sources */,
 				F93899A826B007730065561F /* Errors.swift in Sources */,

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -98,7 +98,8 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
     /// :nodoc:
     public func perform<R: Request>(_ request: R, completionHandler: @escaping CompletionHandler<R.ResponseType>) {
         do {
-            urlSession.dataTask(with: try buildUrlRequest(from: request)) { result in
+            urlSession.dataTask(with: try buildUrlRequest(from: request)) { [weak self] result in
+                guard let self = self else { return }
                 let result = result
                     .flatMap { response in .init(catching: { try self.handle(response, request) }) }
                     .map(\.responseBody)
@@ -228,7 +229,7 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
         
         return config
     }
-    
+
 }
 
 private func printAsJSON(_ data: Data) {

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -66,6 +66,7 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
     ///   - apiContext: The API context.
     ///   - configuration: An optional `URLSessionConfiguration` to be used.
     ///   If no value is provided - `URLSessionConfiguration.ephemereal` will be used.
+    ///   - coder: The coder used for encoding request's body and parsing response's body
     public init(
         apiContext: AnyAPIContext,
         configuration: URLSessionConfiguration? = nil,

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -57,19 +57,27 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
     /// :nodoc:
     private let urlSession: URLSession
     
+    /// Encoding and Decoding
+    private let coder: AnyCoder
+
     /// Initializes the API client.
     ///
     /// - Parameters:
     ///   - apiContext: The API context.
     ///   - configuration: An optional `URLSessionConfiguration` to be used.
     ///   If no value is provided - `URLSessionConfiguration.ephemereal` will be used.
-    public init(apiContext: AnyAPIContext, configuration: URLSessionConfiguration? = nil) {
+    public init(
+        apiContext: AnyAPIContext,
+        configuration: URLSessionConfiguration? = nil,
+        coder: AnyCoder = Coder()
+    ) {
         self.apiContext = apiContext
         self.urlSession = URLSession(
             configuration: configuration ?? Self.buildDefaultConfiguration(),
             delegate: nil,
             delegateQueue: .main
         )
+        self.coder = coder
     }
     
     /// Performs the API request asynchronously.
@@ -84,7 +92,7 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
         let result = try await urlSession
             .data(for: try buildUrlRequest(from: request)) as (data: Data, urlResponse: URLResponse)
         let httpResult = try URLSessionSuccess(data: result.data, response: result.urlResponse)
-        return try Self.handle(httpResult, request)
+        return try handle(httpResult, request)
     }
     
     /// :nodoc:
@@ -92,7 +100,7 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
         do {
             urlSession.dataTask(with: try buildUrlRequest(from: request)) { result in
                 let result = result
-                    .flatMap { response in .init(catching: { try Self.handle(response, request) }) }
+                    .flatMap { response in .init(catching: { try self.handle(response, request) }) }
                     .map(\.responseBody)
                     .mapError { (error) -> Error in
                         switch error {
@@ -119,7 +127,7 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
         urlRequest.httpMethod = request.method.rawValue
         urlRequest.allHTTPHeaderFields = request.headers.merging(apiContext.headers, uniquingKeysWith: { key1, _ in key1 })
         if request.method.hasBody {
-            urlRequest.httpBody = try Coder.encode(request)
+            urlRequest.httpBody = try coder.encode(request)
         }
         
         log(urlRequest: urlRequest, request: request)
@@ -127,7 +135,7 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
         return urlRequest
     }
     
-    private static func handle<R: Request>(
+    private func handle<R: Request>(
         _ result: URLSessionSuccess,
         _ request: R
     ) throws -> HTTPResponse<R.ResponseType> {
@@ -143,11 +151,11 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
                 return HTTPResponse(
                     headers: result.headers,
                     statusCode: result.statusCode,
-                    responseBody: try Coder.decode(result.data) as R.ResponseType
+                    responseBody: try coder.decode(R.ResponseType.self, from: result.data)
                 )
             }
         } catch {
-            if let errorResponse: R.ErrorResponseType = try? Coder.decode(result.data) {
+            if let errorResponse = try? coder.decode(R.ErrorResponseType.self, from: result.data){
                 throw HTTPErrorResponse(
                     headers: result.headers,
                     statusCode: result.statusCode,
@@ -187,7 +195,7 @@ public final class APIClient: APIClientProtocol, AsyncAPIClientProtocol {
         
     }
     
-    private static func log<R: Request>(result: URLSessionSuccess, request: R) {
+    private func log<R: Request>(result: URLSessionSuccess, request: R) {
         adyenPrint("---- Response Code (/\(request.path)) ----")
         adyenPrint(result.statusCode)
         

--- a/AdyenNetworking/APIClient/AnyCoder.swift
+++ b/AdyenNetworking/APIClient/AnyCoder.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Emrah Akgul on 05/08/2022.
+//
+
+import Foundation
+
+public protocol AnyCoder {
+    
+    func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}

--- a/AdyenNetworking/Helpers/Coder.swift
+++ b/AdyenNetworking/Helpers/Coder.swift
@@ -8,70 +8,35 @@ import Foundation
 
 /// An object that provides helper functions for conding and deconding responses.
 /// :nodoc:
-public enum Coder {
+public class Coder: AnyCoder {
+    
+    public init() {}
     
     // MARK: - Decoding
     
     /// :nodoc:
-    public static func decode<T: Decodable>(_ data: Data) throws -> T {
+    public func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         try decoder.decode(T.self, from: data)
-    }
-    
-    /// :nodoc:
-    public static func decode<T: Decodable>(_ string: String) throws -> T {
-        try decode(Data(string.utf8))
-    }
-    
-    /// :nodoc:
-    public static func decodeBase64<T: Decodable>(_ string: String) throws -> T {
-        guard let data = Data(base64Encoded: string) else {
-            let context = DecodingError.Context(codingPath: [], debugDescription: "Given string is not valid base64.")
-            
-            throw DecodingError.dataCorrupted(context)
-        }
-        
-        return try decode(data) as T
     }
     
     // MARK: - Encoding
     
     /// :nodoc:
-    public static func encode<T: Encodable>(_ value: T) throws -> Data {
+    public func encode<T: Encodable>(_ value: T) throws -> Data {
         try encoder.encode(value)
-    }
-    
-    /// :nodoc:
-    public static func encode<T: Encodable>(_ value: T) throws -> String {
-        let data: Data = try encode(value)
-        
-        guard let string = String(data: data, encoding: .utf8) else {
-            fatalError("Failed to convert data to UTF-8 string.")
-        }
-        
-        return string
-    }
-    
-    /// :nodoc:
-    public static func encodeBase64<T: Encodable>(_ value: T) throws -> String {
-        let encodedValue = try encode(value) as Data
-        
-        return encodedValue.base64EncodedString()
     }
     
     // MARK: - Private
     
-    private static let decoder: JSONDecoder = {
+    private let decoder: JSONDecoder = {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        
         return decoder
     }()
     
-    private static let encoder: JSONEncoder = {
+    private let encoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        
         return encoder
     }()
-    
 }


### PR DESCRIPTION
## Summary

Using Coder restricts us from using custom encoding and decoding unless we change Coder in this repository. By providing concrete implementation for AnyCoder and injecting it in the initializer, we will be able to encode and decode in a custom manner.

## Tested scenarios

All test cases are seen to be passed in the project.
