### PR TITLE
Add handling of http error codes before async download starts

### DIFF
--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -49,6 +49,7 @@ public protocol AsyncAPIClientProtocol: AnyObject {
     /// - Parameter request: The ``AsyncDownloadRequest`` to be performed.
     /// - Returns: ``HTTPResponse`` in case of successful response.
     /// - Throws: ``APIClientError.invalidResponse`` in case of invalid HTTP response.
+    /// - Throws: ``HTTPErrorResponse`` in case of HTTP error code response. 
     ///
     /// The ``DownloadResponse`` `ResponseType` of the ``HTTPResponse`` contains the destination `URL` to the system's temporary directory containing the downloaded file including an appropriate filename.
     func perform<R>(_ request: R) async throws -> HTTPResponse<R.ResponseType> where R: AsyncDownloadRequest, R.ResponseType == DownloadResponse

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -34,13 +34,14 @@ public protocol AsyncAPIClientProtocol: AnyObject {
     /// - Returns: ``HTTPResponse`` in case of successful response.
     /// - Throws: ``HTTPErrorResponse`` in case of an HTTP error.
     /// - Throws: ``ParsingError`` in case of an error during response decoding.
-    /// - Throws: ``APIClientError.invalidResponse`` in case of invalid HTTP response.
+    /// - Throws: ``APIClientError`` in case of invalid HTTP response.
     func perform<R>(_ request: R) async throws -> HTTPResponse<R.ResponseType> where R: Request
     
     /// Performs the API request to download asynchronously.
     /// - Parameter request: The ``Request`` to be performed.
     /// - Returns: ``HTTPResponse`` in case of successful response.
-    /// - Throws: ``APIClientError.invalidResponse`` in case of invalid HTTP response.
+    /// - Throws: ``APIClientError`` in case of invalid HTTP response.
+    /// - Throws: ``HTTPErrorResponse`` in case of HTTP error.
     ///
     /// The ``DownloadResponse`` `ResponseType` of the ``HTTPResponse`` contains the destination `URL` to the system's temporary directory containing the downloaded file including an appropriate filename.
     func perform<R>(_ request: R) async throws -> HTTPResponse<R.ResponseType> where R: Request, R.ResponseType == DownloadResponse
@@ -48,8 +49,8 @@ public protocol AsyncAPIClientProtocol: AnyObject {
     /// Performs the API download request asynchronously, providing progress updates to the `onProgressUpdate(Double)` callback on ``AsyncDownloadRequest``.
     /// - Parameter request: The ``AsyncDownloadRequest`` to be performed.
     /// - Returns: ``HTTPResponse`` in case of successful response.
-    /// - Throws: ``APIClientError.invalidResponse`` in case of invalid HTTP response.
-    /// - Throws: ``HTTPErrorResponse`` in case of HTTP error code response. 
+    /// - Throws: ``APIClientError`` in case of invalid HTTP response.
+    /// - Throws: ``HTTPErrorResponse`` in case of HTTP error.
     ///
     /// The ``DownloadResponse`` `ResponseType` of the ``HTTPResponse`` contains the destination `URL` to the system's temporary directory containing the downloaded file including an appropriate filename.
     func perform<R>(_ request: R) async throws -> HTTPResponse<R.ResponseType> where R: AsyncDownloadRequest, R.ResponseType == DownloadResponse
@@ -325,6 +326,7 @@ extension APIClient: AsyncAPIClientProtocol {
     ) async throws -> HTTPResponse<R.ResponseType> where R: Request, R.ResponseType == DownloadResponse {
         let urlRequest = try buildUrlRequest(from: request)
         let (locationUrl, urlResponse) = try await urlSession.download(for: urlRequest)
+        try handleHttpErrorCodes(from: urlResponse)
         let destinationUrl = try generateFileDestination(
             given: generateFilename(from: urlResponse, with: urlRequest)
         )

--- a/Networking Demo AppTests/APIClientTests.swift
+++ b/Networking Demo AppTests/APIClientTests.swift
@@ -145,6 +145,22 @@ class APIClientTests: XCTestCase {
         await waitForExpectations(timeout: 10, handler: nil)
     }
     
+    @available(iOS 15.0.0, *)
+    func testAsyncFailedDownloadRequest() async throws {
+        var request = TestAsyncDownloadRequest { progress in
+            XCTFail("Callback should not be triggered for failed download.")
+        }
+        request.path = "kljhfkajsdhfs/////df345.345345m34feg45435"
+        let api = APIClient(apiContext: SimpleAPIContext())
+        
+        do {
+            let _ = try await api.perform(request)
+            XCTFail("Error was not thrown as it should be.")
+        } catch let error {
+            XCTAssertNotNil(error)
+        }
+    }
+    
     func testCompletionHandlerDownloadRequest() throws {
         let apiClientExpectation = expectation(description: "Expect api client to download image file.")
         let request = TestDownloadRequest()

--- a/Networking Demo AppTests/APIClientTests.swift
+++ b/Networking Demo AppTests/APIClientTests.swift
@@ -124,7 +124,7 @@ class APIClientTests: XCTestCase {
     }
     
     @available(iOS 15.0.0, *)
-    func testAsyncDownloadRequest() async throws {
+    func testAsyncCallbackDownloadRequest() async throws {
         let downloadProgressExpectation = expectation(description: "Expect download progress to reach 100%.")
         let request = TestAsyncDownloadRequest { progress in
             if progress == 1.0 {
@@ -146,10 +146,24 @@ class APIClientTests: XCTestCase {
     }
     
     @available(iOS 15.0.0, *)
-    func testAsyncFailedDownloadRequest() async throws {
+    func testAsyncCallbackFailedDownloadRequest() async throws {
         var request = TestAsyncDownloadRequest { progress in
             XCTFail("Callback should not be triggered for failed download.")
         }
+        request.path = "kljhfkajsdhfs/////df345.345345m34feg45435"
+        let api = APIClient(apiContext: SimpleAPIContext())
+        
+        do {
+            let _ = try await api.perform(request)
+            XCTFail("Error was not thrown as it should be.")
+        } catch let error {
+            XCTAssertNotNil(error)
+        }
+    }
+    
+    @available(iOS 15.0.0, *)
+    func testAsyncFailedDownloadRequest() async throws {
+        var request = TestDownloadRequest()
         request.path = "kljhfkajsdhfs/////df345.345345m34feg45435"
         let api = APIClient(apiContext: SimpleAPIContext())
         

--- a/Networking Demo AppTests/APIClientTests.swift
+++ b/Networking Demo AppTests/APIClientTests.swift
@@ -161,7 +161,7 @@ class APIClientTests: XCTestCase {
                 XCTFail("Unknown error thrown")
                 return
             }
-            XCTAssertTrue(errorResponse.statusCode == 400)
+            XCTAssertEqual(errorResponse.statusCode, 400)
         }
     }
     
@@ -179,7 +179,7 @@ class APIClientTests: XCTestCase {
                 XCTFail("Unknown error thrown")
                 return
             }
-            XCTAssertTrue(errorResponse.statusCode == 400)
+            XCTAssertEqual(errorResponse.statusCode, 400)
         }
     }
     

--- a/Networking Demo AppTests/APIClientTests.swift
+++ b/Networking Demo AppTests/APIClientTests.swift
@@ -157,7 +157,11 @@ class APIClientTests: XCTestCase {
             let _ = try await api.perform(request)
             XCTFail("Error was not thrown as it should be.")
         } catch let error {
-            XCTAssertNotNil(error)
+            guard let errorResponse = error as? HTTPErrorResponse<EmptyErrorResponse> else {
+                XCTFail("Unknown error thrown")
+                return
+            }
+            XCTAssertTrue(errorResponse.statusCode == 400)
         }
     }
     
@@ -171,7 +175,11 @@ class APIClientTests: XCTestCase {
             let _ = try await api.perform(request)
             XCTFail("Error was not thrown as it should be.")
         } catch let error {
-            XCTAssertNotNil(error)
+            guard let errorResponse = error as? HTTPErrorResponse<EmptyErrorResponse> else {
+                XCTFail("Unknown error thrown")
+                return
+            }
+            XCTAssertTrue(errorResponse.statusCode == 400)
         }
     }
     


### PR DESCRIPTION
## Summary
Currently the issue is that error status codes are returned and not thrown and thus the async download downloads a dummy text file. This fix handles the error codes before the async download starts.

## Tested scenarios
Added a test with a malformed URL to simulate a 400 error code.