### PR TITLE
add responseBody param to Response

### DIFF
--- a/AdyenNetworking.xcodeproj/project.pbxproj
+++ b/AdyenNetworking.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		5A2AEC7327B1A871004694C9 /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2AEC7227B1A871004694C9 /* HTTPResponse.swift */; };
 		82D5C1D128E59D7F00179E66 /* TestDownloadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D5C1D028E59D7F00179E66 /* TestDownloadRequest.swift */; };
 		82EC1A1828ED7D8600F47B10 /* MockScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EC1A1728ED7D8600F47B10 /* MockScheduler.swift */; };
+		AE47E089296484D10011E81A /* HTTPDataResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE47E088296484D10011E81A /* HTTPDataResponse.swift */; };
+		AEE2298B2949DF3E009B926B /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2298A2949DF3E009B926B /* Response.swift */; };
 		B14E1D8F28A27F1D00E36290 /* AnyCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14E1D8E28A27F1D00E36290 /* AnyCoder.swift */; };
 		F913B3AD26B1854F008F6CD2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913B3AC26B1854F008F6CD2 /* AppDelegate.swift */; };
 		F913B3AF26B1854F008F6CD2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913B3AE26B1854F008F6CD2 /* SceneDelegate.swift */; };
@@ -87,6 +89,8 @@
 		5A2AEC7227B1A871004694C9 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
 		82D5C1D028E59D7F00179E66 /* TestDownloadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDownloadRequest.swift; sourceTree = "<group>"; };
 		82EC1A1728ED7D8600F47B10 /* MockScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockScheduler.swift; sourceTree = "<group>"; };
+		AE47E088296484D10011E81A /* HTTPDataResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDataResponse.swift; sourceTree = "<group>"; };
+		AEE2298A2949DF3E009B926B /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		B14E1D8E28A27F1D00E36290 /* AnyCoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCoder.swift; sourceTree = "<group>"; };
 		F913B3AA26B1854F008F6CD2 /* Networking Demo App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Networking Demo App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F913B3AC26B1854F008F6CD2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -289,6 +293,8 @@
 				F938998C26B0059E0065561F /* Scheduler.swift */,
 				F938998A26B0059E0065561F /* SimpleScheduler.swift */,
 				F938998F26B0059E0065561F /* UniqueAssetAPIClient.swift */,
+				AEE2298A2949DF3E009B926B /* Response.swift */,
+				AE47E088296484D10011E81A /* HTTPDataResponse.swift */,
 			);
 			path = APIClient;
 			sourceTree = "<group>";
@@ -505,9 +511,11 @@
 				F938999826B005B00065561F /* Request.swift in Sources */,
 				F938999026B0059E0065561F /* RetryAPIClient.swift in Sources */,
 				F938999326B0059E0065561F /* Scheduler.swift in Sources */,
+				AEE2298B2949DF3E009B926B /* Response.swift in Sources */,
 				F938999B26B005D70065561F /* AnyAPIContext.swift in Sources */,
 				F938999126B0059E0065561F /* SimpleScheduler.swift in Sources */,
 				F938999626B0059E0065561F /* UniqueAssetAPIClient.swift in Sources */,
+				AE47E089296484D10011E81A /* HTTPDataResponse.swift in Sources */,
 				F938999226B0059E0065561F /* APIClient.swift in Sources */,
 				F93899A226B006610065561F /* URLSessionHelpers.swift in Sources */,
 				F938999426B0059E0065561F /* RetryOnErrorAPIClient.swift in Sources */,

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -181,7 +181,7 @@ public final class APIClient: APIClientProtocol {
                     headers: result.headers,
                     statusCode: result.statusCode,
                     responseBody: emptyResponse,
-                    responseData: Data()
+                    responseData: result.data
                 )
             } else {
                 return HTTPDataResponse(
@@ -196,13 +196,16 @@ public final class APIClient: APIClientProtocol {
                 throw HTTPErrorResponse(
                     headers: result.headers,
                     statusCode: result.statusCode,
-                    responseBody: errorResponse
+                    responseBody: errorResponse,
+                    responseData: result.data
                 )
             } else if let decodingError = error as? DecodingError {
                 throw ParsingError(
                     headers: result.headers,
                     statusCode: result.statusCode,
-                    underlyingError: decodingError
+                    underlyingError: decodingError,
+                    responseBody: EmptyResponse(),
+                    responseData: result.data
                 )
             } else {
                 throw error
@@ -377,7 +380,8 @@ extension APIClient: AsyncAPIClientProtocol {
             throw HTTPErrorResponse(
                 headers: headers,
                 statusCode: httpResponse.statusCode,
-                responseBody: EmptyErrorResponse()
+                responseBody: EmptyErrorResponse(),
+                responseData: Data()
             )
         }
     }

--- a/AdyenNetworking/APIClient/AnyAPIContext.swift
+++ b/AdyenNetworking/APIClient/AnyAPIContext.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/APIClient/AnyAPIEnvironment.swift
+++ b/AdyenNetworking/APIClient/AnyAPIEnvironment.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/APIClient/AnyCoder.swift
+++ b/AdyenNetworking/APIClient/AnyCoder.swift
@@ -1,8 +1,7 @@
 //
-//  File.swift
-//  
+// Copyright (c) 2023 Adyen N.V.
 //
-//  Created by Emrah Akgul on 05/08/2022.
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
 import Foundation

--- a/AdyenNetworking/APIClient/BackoffScheduler.swift
+++ b/AdyenNetworking/APIClient/BackoffScheduler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/APIClient/Errors.swift
+++ b/AdyenNetworking/APIClient/Errors.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/APIClient/Errors.swift
+++ b/AdyenNetworking/APIClient/Errors.swift
@@ -20,7 +20,7 @@ public enum APIClientError: LocalizedError {
 /// Represents a parsing error object
 public struct ParsingError: LocalizedError, AnyDataResponse {
     
-    typealias R = EmptyResponse
+    public typealias R = EmptyResponse
     
     /// HTTP Headers.
     public let headers: [String: String]
@@ -32,7 +32,7 @@ public struct ParsingError: LocalizedError, AnyDataResponse {
     public let underlyingError: DecodingError
     
     /// Empty response body
-    var responseBody: EmptyResponse
+    public var responseBody: EmptyResponse
     
     /// The response data which was failed to be parsed
     var responseData: Data

--- a/AdyenNetworking/APIClient/Errors.swift
+++ b/AdyenNetworking/APIClient/Errors.swift
@@ -18,7 +18,9 @@ public enum APIClientError: LocalizedError {
 }
 
 /// Represents a parsing error object
-public struct ParsingError: LocalizedError {
+public struct ParsingError: LocalizedError, AnyDataResponse {
+    
+    typealias R = EmptyResponse
     
     /// HTTP Headers.
     public let headers: [String: String]
@@ -29,4 +31,9 @@ public struct ParsingError: LocalizedError {
     /// Underlying error of type ``DecodingError``
     public let underlyingError: DecodingError
     
+    /// Empty response body
+    var responseBody: EmptyResponse
+    
+    /// The response data which was failed to be parsed
+    var responseData: Data
 }

--- a/AdyenNetworking/APIClient/HTTPDataResponse.swift
+++ b/AdyenNetworking/APIClient/HTTPDataResponse.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Protocol representing a HTTP response which contains raw response
 protocol AnyDataResponse: AnyHTTPResponse {
     
-    /// Response data representing the raw response info
+    /// Response data representing the raw response info in `Data`
     var responseData: Data { get }
 }
 
@@ -28,3 +28,7 @@ public struct HTTPDataResponse<R: Response>: AnyDataResponse {
     /// Raw data response
     public let responseData: Data
 }
+
+public typealias HTTPErrorResponse<E: ErrorResponse> = HTTPDataResponse<E>
+
+extension HTTPDataResponse: Error where R: Error { }

--- a/AdyenNetworking/APIClient/HTTPDataResponse.swift
+++ b/AdyenNetworking/APIClient/HTTPDataResponse.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+import Foundation
+
+/// Protocol representing a HTTP response which contains raw response
+protocol AnyDataResponse: AnyHTTPResponse {
+    
+    /// Response data representing the raw response info
+    var responseData: Data { get }
+}
+
+/// Struct conforming to `AnyDataResponse` which contains standard HTTP response info, including headers,
+/// status code and response body, as well as the raw `Data` response
+public struct HTTPDataResponse<R: Response>: AnyDataResponse {
+    
+    /// HTTP Headers.
+    public let headers: [String: String]
+    
+    /// HTTP Status Code.
+    public let statusCode: Int
+    
+    /// Response body
+    public let responseBody: R
+    
+    /// Raw data response
+    public let responseData: Data
+}

--- a/AdyenNetworking/APIClient/HTTPResponse.swift
+++ b/AdyenNetworking/APIClient/HTTPResponse.swift
@@ -1,12 +1,28 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
 import Foundation
 
-public struct HTTPResponse<R: Response> {
+/// Protocol representing a HTTP response, containing headers, status code and body
+protocol AnyHTTPResponse {
+    
+    associatedtype R
+    
+    /// HTTP Headers.
+    var headers: [String: String] { get }
+    
+    /// HTTP Status Code.
+    var statusCode: Int { get }
+    
+    /// Response body
+    var responseBody: R { get }
+}
+
+/// Struct conforming to `AnyHTTPResponse` which contains standard HTTP response info, ie headers, status code and response body
+public struct HTTPResponse<R: Response>: AnyHTTPResponse {
     
     /// HTTP Headers.
     public let headers: [String: String]
@@ -16,7 +32,6 @@ public struct HTTPResponse<R: Response> {
     
     /// Response body
     public let responseBody: R
-    
 }
 
 public typealias HTTPErrorResponse<E: ErrorResponse> = HTTPResponse<E>

--- a/AdyenNetworking/APIClient/HTTPResponse.swift
+++ b/AdyenNetworking/APIClient/HTTPResponse.swift
@@ -33,7 +33,3 @@ public struct HTTPResponse<R: Response>: AnyHTTPResponse {
     /// Response body
     public let responseBody: R
 }
-
-public typealias HTTPErrorResponse<E: ErrorResponse> = HTTPResponse<E>
-
-extension HTTPResponse: Error where R: Error { }

--- a/AdyenNetworking/APIClient/HTTPResponse.swift
+++ b/AdyenNetworking/APIClient/HTTPResponse.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Protocol representing a HTTP response, containing headers, status code and body
-protocol AnyHTTPResponse {
+public protocol AnyHTTPResponse {
     
     associatedtype R
     

--- a/AdyenNetworking/APIClient/Request.swift
+++ b/AdyenNetworking/APIClient/Request.swift
@@ -45,7 +45,7 @@ public protocol Request: Encodable {
     
     /// :nodoc:
     /// The HTTP headers.
-    var headers: [String: String] { get }
+    var headers: [String: String] { get set }
     
     /// :nodoc:
     /// The query parameters.

--- a/AdyenNetworking/APIClient/Request.swift
+++ b/AdyenNetworking/APIClient/Request.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -57,43 +57,7 @@ public protocol Request: Encodable {
 }
 
 /// Describes a ``Request`` extension to be used for async downloading.
-///
-/// A ``DownloadProgressDelegate`` is provided for progress updates.
 @available(iOS 15.0.0, *)
 public protocol AsyncDownloadRequest: Request {
     var onProgressUpdate: ((_ progress: Double) -> Void)? { get }
 }
-
-/// Describes an API response.
-public protocol Response: Decodable { }
-
-/// Represents an API download response.
-///
-/// The `url` property provides the temporary path to the downloaded file.
-public struct DownloadResponse: Response {
-    public let url: URL
-    
-    public init(url: URL) {
-        self.url = url
-    }
-    
-    enum CodingKeys: CodingKey {
-        case url
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.url = try container.decode(URL.self, forKey: .url)
-    }
-}
-
-/// Represents an empty API response.
-public struct EmptyResponse: Response {
-    public init() { }
-}
-
-/// Describes an API Error response.
-public protocol ErrorResponse: Response, Error { }
-
-/// Represents an empty API Error response.
-public struct EmptyErrorResponse: ErrorResponse { }

--- a/AdyenNetworking/APIClient/Response.swift
+++ b/AdyenNetworking/APIClient/Response.swift
@@ -39,3 +39,7 @@ public protocol ErrorResponse: Response, Error { }
 
 /// Represents an empty API Error response.
 public struct EmptyErrorResponse: ErrorResponse { }
+
+public struct ParsingErrorResponse: ErrorResponse {
+    public init() { }
+}

--- a/AdyenNetworking/APIClient/Response.swift
+++ b/AdyenNetworking/APIClient/Response.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+/// Describes an API response.
+public protocol Response: Decodable { }
+
+/// Represents an API download response.
+///
+/// The `url` property provides the temporary path to the downloaded file.
+public struct DownloadResponse: Response {
+    public let url: URL
+    
+    public init(url: URL) {
+        self.url = url
+    }
+    
+    enum CodingKeys: CodingKey {
+        case url
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.url = try container.decode(URL.self, forKey: .url)
+    }
+}
+
+/// Represents an empty API response.
+public struct EmptyResponse: Response {
+    public init() { }
+}
+
+/// Describes an API Error response.
+public protocol ErrorResponse: Response, Error { }
+
+/// Represents an empty API Error response.
+public struct EmptyErrorResponse: ErrorResponse { }

--- a/AdyenNetworking/APIClient/RetryAPIClient.swift
+++ b/AdyenNetworking/APIClient/RetryAPIClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/APIClient/RetryOnErrorAPIClient.swift
+++ b/AdyenNetworking/APIClient/RetryOnErrorAPIClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/APIClient/Scheduler.swift
+++ b/AdyenNetworking/APIClient/Scheduler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/APIClient/SimpleScheduler.swift
+++ b/AdyenNetworking/APIClient/SimpleScheduler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/APIClient/UniqueAssetAPIClient.swift
+++ b/AdyenNetworking/APIClient/UniqueAssetAPIClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/AdyenNetworking.h
+++ b/AdyenNetworking/AdyenNetworking.h
@@ -1,7 +1,7 @@
 //
 //  AdyenNetworking.h
 //  AdyenNetworking
-//  Copyright (c) 2022 Adyen N.V.
+//  Copyright (c) 2023 Adyen N.V.
 //
 //  This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/Helpers/Coder.swift
+++ b/AdyenNetworking/Helpers/Coder.swift
@@ -1,12 +1,12 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
 import Foundation
 
-/// An object that provides helper functions for conding and deconding responses.
+/// An object that provides helper functions for coding and decoding responses.
 /// :nodoc:
 public class Coder: AnyCoder {
     

--- a/AdyenNetworking/Helpers/Logging.swift
+++ b/AdyenNetworking/Helpers/Logging.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/Helpers/URLHelpers.swift
+++ b/AdyenNetworking/Helpers/URLHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenNetworking/Helpers/URLSessionHelpers.swift
+++ b/AdyenNetworking/Helpers/URLSessionHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -33,6 +33,8 @@ internal struct URLSessionDownloadSuccess {
     
     internal let headers: [String: String]
     
+    internal let data: Data
+    
     internal init(url: URL?, response: URLResponse?) throws {
         guard let url = url,
               let httpResponse = response as? HTTPURLResponse,
@@ -43,6 +45,7 @@ internal struct URLSessionDownloadSuccess {
         self.url = url
         self.headers = headers
         self.statusCode = httpResponse.statusCode
+        self.data = (try? Data(contentsOf: url)) ?? Data()
     }
 }
 

--- a/AdyenNetworkingTests/AdyenNetworkingTests.swift
+++ b/AdyenNetworkingTests/AdyenNetworkingTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Networking Demo App/API/Requests/CreateUsersRequest.swift
+++ b/Networking Demo App/API/Requests/CreateUsersRequest.swift
@@ -33,7 +33,7 @@ internal struct CreateUsersRequest: Request {
     
     var counter: UInt = 0
     
-    let headers: [String : String] = [:]
+    var headers: [String : String] = [:]
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()

--- a/Networking Demo App/API/Requests/GetUsersRequest.swift
+++ b/Networking Demo App/API/Requests/GetUsersRequest.swift
@@ -32,7 +32,7 @@ internal struct GetUsersRequest: Request {
     
     var counter: UInt = 0
     
-    let headers: [String : String] = [:]
+    var headers: [String : String] = [:]
     
     private enum CodingKeys: CodingKey {}
 }

--- a/Networking Demo App/API/Requests/InvalidCreateUsersRequest.swift
+++ b/Networking Demo App/API/Requests/InvalidCreateUsersRequest.swift
@@ -22,7 +22,7 @@ internal struct InvalidCreateUsersRequest: Request {
     
     var counter: UInt = 0
     
-    let headers: [String : String] = [:]
+    var headers: [String : String] = [:]
     
     private enum CodingKeys: CodingKey {}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

Add responseData param to capture the unserialized response data, allowing the caller access to the raw binary response data without needing to make `Response` conform to `Encodable`
