### PR TITLE
Make headers property settable

### DIFF
--- a/AdyenNetworking/APIClient/Request.swift
+++ b/AdyenNetworking/APIClient/Request.swift
@@ -45,7 +45,7 @@ public protocol Request: Encodable {
     
     /// :nodoc:
     /// The HTTP headers.
-    var headers: [String: String] { get }
+    var headers: [String: String] { get set }
     
     /// :nodoc:
     /// The query parameters.

--- a/Networking Demo App/API/Requests/CreateUsersRequest.swift
+++ b/Networking Demo App/API/Requests/CreateUsersRequest.swift
@@ -32,7 +32,7 @@ internal struct CreateUsersRequest: Request {
     
     var counter: UInt = 0
     
-    let headers: [String : String] = [:]
+    var headers: [String : String] = [:]
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()

--- a/Networking Demo App/API/Requests/GetUsersRequest.swift
+++ b/Networking Demo App/API/Requests/GetUsersRequest.swift
@@ -31,7 +31,7 @@ internal struct GetUsersRequest: Request {
     
     var counter: UInt = 0
     
-    let headers: [String : String] = [:]
+    var headers: [String : String] = [:]
     
     private enum CodingKeys: CodingKey {}
 }

--- a/Networking Demo App/API/Requests/InvalidCreateUsersRequest.swift
+++ b/Networking Demo App/API/Requests/InvalidCreateUsersRequest.swift
@@ -21,7 +21,7 @@ internal struct InvalidCreateUsersRequest: Request {
     
     var counter: UInt = 0
     
-    let headers: [String : String] = [:]
+    var headers: [String : String] = [:]
     
     private enum CodingKeys: CodingKey {}
 }

--- a/Networking Demo AppTests/APIClientTests.swift
+++ b/Networking Demo AppTests/APIClientTests.swift
@@ -313,10 +313,10 @@ enum ValidationError: Error {
 }
 
 public class MockResponseValidator: AnyResponseValidator {
-    
+
     var onValidated: (() throws -> Void)?
     
-    public func validate<R>(_ responseData: Data, for request: R, with responseHeaders: [AnyHashable : Any]) throws {
+    public func validate<R>(_ responseData: Data, for request: R, with responseHeaders: [String : String]) throws {
         try onValidated?()
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
1. Make `headers` property in `Request` settable.
2. Updated request objects in demo app.
3. Updated `MockResponseValidator` to conform to `AnyResponseValidator `.
