### PR TITLE
Make AsyncAPIClient available for iOS 13

### DIFF
--- a/.github/workflows/test-SPM-integration.yml
+++ b/.github/workflows/test-SPM-integration.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: n1hility/cancel-previous-runs@v2
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test-carthage-integration.yml
+++ b/.github/workflows/test-carthage-integration.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: n1hility/cancel-previous-runs@v2
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: n1hility/cancel-previous-runs@v2
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -27,7 +27,7 @@ public protocol APIClientProtocol: AnyObject {
 
 /// :nodoc:
 /// Describes any async API Client.
-@available(iOS 15.0.0, *)
+@available(iOS 13.0.0, *)
 public protocol AsyncAPIClientProtocol: AnyObject {
     /// Performs the API request asynchronously.
     /// - Parameter request: The ``Request`` to be performed.
@@ -336,7 +336,7 @@ public final class APIClient: APIClientProtocol {
 }
 
 extension APIClient: AsyncAPIClientProtocol {
-    @available(iOS 15.0.0, *)
+    @available(iOS 13.0.0, *)
     public func perform<R>(_ request: R) async throws -> HTTPResponse<R.ResponseType> where R: Request {
         let result = try await urlSession
             .data(for: try buildUrlRequest(from: request)) as (data: Data, urlResponse: URLResponse)
@@ -344,7 +344,7 @@ extension APIClient: AsyncAPIClientProtocol {
         return try handle(httpResult, request)
     }
     
-    @available(iOS 15.0.0, *)
+    @available(iOS 13.0.0, *)
     public func perform<R>(
         _ request: R
     ) async throws -> HTTPResponse<R.ResponseType> where R: Request, R.ResponseType == DownloadResponse {
@@ -359,7 +359,7 @@ extension APIClient: AsyncAPIClientProtocol {
         return try handle(httpResult, request)
     }
     
-    @available(iOS 15.0.0, *)
+    @available(iOS 13.0.0, *)
     public func perform<R>(
         _ request: R
     ) async throws -> HTTPResponse<R.ResponseType> where R: AsyncDownloadRequest, R.ResponseType == DownloadResponse {


### PR DESCRIPTION
As async/await is available for iOS 13 and up, this PR changes the availability tags to reflect that, making it possible to use `AsyncAPIClient` on those iOS versions.