### PR TITLE
Adding global @_spi adyenPrintAsJSON back

### DIFF
--- a/AdyenNetworking/Helpers/Logging/DebugLogging.swift
+++ b/AdyenNetworking/Helpers/Logging/DebugLogging.swift
@@ -24,7 +24,7 @@ internal extension DebugLogging {
     func printAsJSON(_ dictionary: [String : Any], fileId: String = #fileID) {
         guard Logging.isEnabled else { return }
         do {
-            let jsonData = try JSONSerialization.data(withJSONObject: dictionary)
+            let jsonData = try JSONSerialization.data(withJSONObject: dictionary, options: .jsonOptions)
             printAsJSON(jsonData, fileId: fileId)
         } catch {
             print(dictionary, fileId: fileId)
@@ -35,7 +35,7 @@ internal extension DebugLogging {
         guard Logging.isEnabled else { return }
         do {
             let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
-            let jsonData = try JSONSerialization.data(withJSONObject: jsonObject)
+            let jsonData = try JSONSerialization.data(withJSONObject: jsonObject, options: .jsonOptions)
             guard let jsonString = String(data: jsonData, encoding: .utf8) else { return }
 
             print(jsonString, fileId: fileId)

--- a/AdyenNetworking/Helpers/Logging/Logging.swift
+++ b/AdyenNetworking/Helpers/Logging/Logging.swift
@@ -15,11 +15,6 @@ public enum Logging {
 // MARK: - Backwards compatible global print
 
 @_spi(AdyenInternal)
-public func adyenPrintAsJSON(_ dictionary: [String: Any], fileId: String = #fileID) {
-    DebugLogger().printAsJSON(dictionary, fileId: fileId)
-}
-
-@_spi(AdyenInternal)
 public func adyenPrintAsJSON(_ data: Data, fileId: String = #fileID) {
     DebugLogger().printAsJSON(data, fileId: fileId)
 }

--- a/AdyenNetworking/Helpers/Logging/Logging.swift
+++ b/AdyenNetworking/Helpers/Logging/Logging.swift
@@ -4,11 +4,22 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import func Darwin.fputs
 import Foundation
 
 /// Provides control over SDK logging.
 public enum Logging {
     /// Indicates whether to enable printing to the console.
     public static var isEnabled: Bool = false
+}
+
+// MARK: - Backwards compatible global print
+
+@_spi(AdyenInternal)
+public func adyenPrintAsJSON(_ dictionary: [String: Any], fileId: String = #fileID) {
+    DebugLogger().printAsJSON(dictionary, fileId: fileId)
+}
+
+@_spi(AdyenInternal)
+public func adyenPrintAsJSON(_ data: Data, fileId: String = #fileID) {
+    DebugLogger().printAsJSON(data, fileId: fileId)
 }

--- a/Tests/UnitTests/APIClientTests.swift
+++ b/Tests/UnitTests/APIClientTests.swift
@@ -68,15 +68,15 @@ struct APIClientTests {
             .init("---- Request base url (/) ----"),
             .init("https://www.adyen.com/"),
             .init("---- Request Headers (/) ----"),
-            .init("{}"),
+            .init("{\n\n}"),
             .init("---- Request query (/) ----"),
-            .init("{}"),
+            .init("{\n\n}"),
             .init("---- Response Code (/) ----"),
             .init("\(response.response!.statusCode)"),
             .init("---- Response Headers (/) ----"),
-            .init("{}"),
+            .init("{\n\n}"),
             .init("---- Response (/) ----"),
-            .init(String(data: response.data!, encoding: .utf8)!)
+            .init(formattedJson(for: response.data!))
         ]
         
         Logging.isEnabled = true
@@ -115,15 +115,15 @@ struct APIClientTests {
             .init("---- Request base url (/) ----"),
             .init("https://www.adyen.com/"),
             .init("---- Request Headers (/) ----"),
-            .init("{}"),
+            .init("{\n\n}"),
             .init("---- Request query (/) ----"),
-            .init("{}"),
+            .init("{\n\n}"),
             .init("---- Response Code (/) ----"),
             .init("\(response.response!.statusCode)"),
             .init("---- Response Headers (/) ----"),
-            .init("{}"),
+            .init("{\n\n}"),
             .init("---- Response (/) ----"),
-            .init(String(data: response.data!, encoding: .utf8)!)
+            .init(formattedJson(for: response.data!))
         ]
         
         Logging.isEnabled = true
@@ -151,24 +151,24 @@ struct APIClientTests {
     
     @Test
     func client_succeeds_onValidMockResponse_withSuccessStatusCode() async throws {
-
+        
+        let expectedResponse = MockResponse(someField: "SomeValue")
+        
         let expectedLogs: [MockDebugLogger.Log] = [
             .init("---- Request (/) ----"),
             .init("---- Request base url (/) ----"),
             .init("https://www.adyen.com/"),
             .init("---- Request Headers (/) ----"),
-            .init("{\"HeaderName\":\"HeaderValue\"}"),
+            .init("{\n  \"HeaderName\" : \"HeaderValue\"\n}"),
             .init("---- Request query (/) ----"),
-            .init("{\"name\":\"value\"}"),
+            .init("{\n  \"name\" : \"value\"\n}"),
             .init("---- Response Code (/) ----"),
             .init("200"),
             .init("---- Response Headers (/) ----"),
-            .init("{}"),
+            .init("{\n\n}"),
             .init("---- Response (/) ----"),
-            .init("{\"someField\":\"SomeValue\"}")
+            .init("{\n  \"someField\" : \"SomeValue\"\n}")
         ]
-        
-        let expectedResponse = MockResponse(someField: "SomeValue")
         
         Logging.isEnabled = true
         let debugLogger = MockDebugLogger()
@@ -222,6 +222,16 @@ private extension APIClientTests {
             ).perform(request) { result in
                 continuation.resume(returning: result)
             }
+        }
+    }
+    
+    func formattedJson(for data: Data) -> String {
+        do {
+            let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+            let jsonData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted, .withoutEscapingSlashes])
+            return String(data: jsonData, encoding: .utf8)!
+        } catch {
+            return String(data: data, encoding: .utf8)!
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adding back global `adyenPrintAsJSON` functions
- Fixing JSON formatting
- Reporting correct module name instead of `AdyenNetworking`
