### PR TITLE
IPPMOB-8706: iOS - AdyenNetworking uses osLog

### DIFF
--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.1'
+        xcode-version: 'latest'
 
     - name: Test Cocoapods Integration
       run: |

--- a/AdyenNetworking/APIClient/APIClient.swift
+++ b/AdyenNetworking/APIClient/APIClient.swift
@@ -83,8 +83,7 @@ public final class APIClient: APIClientProtocol {
     /// Encoding and Decoding
     private let coder: AnyCoder
     
-    /// The debug logger to be used for printing to the console
-    private let logger: any DebugLogging
+    private let logger: (LogCategory) -> any DebugLogging
     
     /// Default file manager
     private let fileManager = FileManager.default
@@ -116,7 +115,7 @@ public final class APIClient: APIClientProtocol {
         )
         self.responseValidator = responseValidator
         self.coder = coder
-        self.logger = DebugLogger()
+        self.logger = DebugLogger.shared(for:)
     }
     
     /// Init for dependency injection / testing
@@ -124,7 +123,7 @@ public final class APIClient: APIClientProtocol {
         apiContext: AnyAPIContext,
         urlSession: URLSession,
         coder: AnyCoder = Coder(),
-        debugLogger: any DebugLogging = DebugLogger(),
+        logger: ((LogCategory) -> any DebugLogging)? = nil,
         responseValidator: (any AnyResponseValidator)? = nil,
         urlSessionDelegate: URLSessionDelegate? = nil
     ) {
@@ -132,7 +131,7 @@ public final class APIClient: APIClientProtocol {
         self.urlSession = urlSession
         self.responseValidator = responseValidator
         self.coder = coder
-        self.logger = debugLogger
+        self.logger = logger ?? DebugLogger.shared(for:)
     }
     
     public func perform<R>(
@@ -267,47 +266,31 @@ public final class APIClient: APIClientProtocol {
     }
     
     private func log<R: Request>(urlRequest: URLRequest, request: R) {
-        logger.print("---- Request (/\(request.path)) ----")
-        
-        if let body = urlRequest.httpBody {
-            logger.printAsJSON(body)
-        }
-        
-        logger.print("---- Request base url (/\(request.path)) ----")
-        logger.print(apiContext.environment.baseURL)
-        
-        if let headers = urlRequest.allHTTPHeaderFields {
-            logger.print("---- Request Headers (/\(request.path)) ----")
-            logger.printAsJSON(headers)
-        }
+        logger(.request).print("\(apiContext.environment.baseURL)/\(request.path)")
         
         if let queryParams = urlRequest.url?.queryParameters {
-            logger.print("---- Request query (/\(request.path)) ----")
-            logger.printAsJSON(queryParams)
+            logger(.request).printAsJSON(queryParams, label: "Query (/\(request.path))")
         }
         
+        if let headers = urlRequest.allHTTPHeaderFields {
+            logger(.request).printAsJSON(headers, label: "Headers (/\(request.path))")
+        }
+        
+        if let body = urlRequest.httpBody {
+            logger(.request).printAsJSON(body, label: "Body (/\(request.path))")
+        }
     }
     
     private func log<R: Request>(result: URLSessionSuccess, request: R) {
-        logger.print("---- Response Code (/\(request.path)) ----")
-        logger.print(result.statusCode)
-        
-        logger.print("---- Response Headers (/\(request.path)) ----")
-        logger.printAsJSON(result.headers)
-        
-        logger.print("---- Response (/\(request.path)) ----")
-        logger.printAsJSON(result.data)
+        logger(.response).print("Status Code (/\(request.path)): \(result.statusCode)")
+        logger(.response).printAsJSON(result.headers, label: "Headers (/\(request.path))")
+        logger(.response).printAsJSON(result.data, label: "Body (/\(request.path))")
     }
     
     private func log<R: Request>(result: URLSessionDownloadSuccess, request: R) {
-        logger.print("---- Response Code (/\(request.path)) ----")
-        logger.print(result.statusCode)
-        
-        logger.print("---- Response Headers (/\(request.path)) ----")
-        logger.printAsJSON(result.headers)
-        
-        logger.print("---- Response (/\(request.path)) ----")
-        logger.print(result.url)
+        logger(.response).print("Status Code (/\(request.path)): \(result.statusCode)")
+        logger(.response).printAsJSON(result.headers, label: "Headers (/\(request.path))")
+        logger(.response).print("Response URL (/\(request.path)): \(result.url)")
     }
     
     /// :nodoc:

--- a/AdyenNetworking/Helpers/Logging/DebugLogger.swift
+++ b/AdyenNetworking/Helpers/Logging/DebugLogger.swift
@@ -6,24 +6,25 @@
 //
 
 import Foundation
+import os.log
 
 internal struct DebugLogger: DebugLogging {
-    
-    func print(_ items: Any..., separator: String, terminator: String, fileId: String) {
+
+    internal static let request = DebugLogger(category: .request)
+    internal static let response = DebugLogger(category: .response)
+
+    internal static func shared(for category: LogCategory) -> any DebugLogging {
+        category == .request ? request : response
+    }
+
+    private let osLog: OSLog
+
+    private init(category: LogCategory) {
+        osLog = OSLog(subsystem: "com.adyen.networking", category: category.rawValue)
+    }
+
+    internal func print(_ message: () -> String) {
         guard Logging.isEnabled else { return }
-        let moduleName = fileId.split(separator: "/").first ?? "AdyenNetworking"
-        
-        let items = [
-            ISO8601DateFormatter().string(from: Date()),
-            "[\(moduleName)]"
-        ] + items
-        
-        var idx = items.startIndex
-        let endIdx = items.endIndex
-        
-        repeat {
-            Swift.print(items[idx], separator: separator, terminator: idx == (endIdx - 1) ? terminator : separator)
-            idx += 1
-        } while idx < endIdx
+        os_log("%{public}@", log: osLog, type: .debug, message())
     }
 }

--- a/AdyenNetworking/Helpers/Logging/DebugLogging.swift
+++ b/AdyenNetworking/Helpers/Logging/DebugLogging.swift
@@ -7,41 +7,45 @@
 
 import Foundation
 
+public enum LogCategory: String {
+    case request
+    case response
+}
+
 internal protocol DebugLogging {
-    
-    func print(_ items: Any..., separator: String, terminator: String, fileId: String)
+
+    func print(_ message: () -> String)
 }
 
 // MARK: - Convenience Extensions
 
 internal extension DebugLogging {
-    
-    func print(_ items: Any..., fileId: String = #fileID) {
+
+    func print(_ message: @autoclosure () -> String) {
         guard Logging.isEnabled else { return }
-        print(items, separator: " ", terminator: "\n", fileId: fileId)
+        print(message)
     }
-    
-    func printAsJSON(_ dictionary: [String : Any], fileId: String = #fileID) {
+
+    func printAsJSON(_ dictionary: [String: Any], label: String = "") {
         guard Logging.isEnabled else { return }
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: dictionary, options: .jsonOptions)
-            printAsJSON(jsonData, fileId: fileId)
+            printAsJSON(jsonData, label: label)
         } catch {
-            print(dictionary, fileId: fileId)
+            print(label.isEmpty ? "\(dictionary)" : "\(label): \(dictionary)")
         }
     }
-    
-    func printAsJSON(_ data: Data, fileId: String = #fileID) {
+
+    func printAsJSON(_ data: Data, label: String = "") {
         guard Logging.isEnabled else { return }
         do {
             let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
             let jsonData = try JSONSerialization.data(withJSONObject: jsonObject, options: .jsonOptions)
             guard let jsonString = String(data: jsonData, encoding: .utf8) else { return }
-
-            print(jsonString, fileId: fileId)
+            print(label.isEmpty ? jsonString : "\(label): \(jsonString)")
         } catch {
             if let string = String(data: data, encoding: .utf8) {
-                print(string, fileId: fileId)
+                print(label.isEmpty ? string : "\(label): \(string)")
             }
         }
     }

--- a/AdyenNetworking/Helpers/Logging/Logging.swift
+++ b/AdyenNetworking/Helpers/Logging/Logging.swift
@@ -15,6 +15,6 @@ public enum Logging {
 // MARK: - Backwards compatible global print
 
 @_spi(AdyenInternal)
-public func adyenPrintAsJSON(_ data: Data, fileId: String = #fileID) {
-    DebugLogger().printAsJSON(data, fileId: fileId)
+public func adyenPrintAsJSON(_ data: Data, _ category: LogCategory = .request, label: String = "") {
+    DebugLogger.shared(for: category).printAsJSON(data, label: label)
 }

--- a/Tests/UnitTests/APIClientTests.swift
+++ b/Tests/UnitTests/APIClientTests.swift
@@ -63,20 +63,13 @@ struct APIClientTests {
     )
     func client_succeeds_onValidEmptyResponse_withSuccessStatusCode(_ response: TestResponse) async throws {
 
-        let expectedLogs: [MockDebugLogger.Log] = [
-            .init("---- Request (/) ----"),
-            .init("---- Request base url (/) ----"),
-            .init("https://www.adyen.com/"),
-            .init("---- Request Headers (/) ----"),
-            .init("{\n\n}"),
-            .init("---- Request query (/) ----"),
-            .init("{\n\n}"),
-            .init("---- Response Code (/) ----"),
-            .init("\(response.response!.statusCode)"),
-            .init("---- Response Headers (/) ----"),
-            .init("{\n\n}"),
-            .init("---- Response (/) ----"),
-            .init(formattedJson(for: response.data!))
+        let expectedLogs: [String] = [
+            "https://www.adyen.com//",
+            "Query (/): {\n\n}",
+            "Headers (/): {\n\n}",
+            "Status Code (/): \(response.response!.statusCode)",
+            "Headers (/): {\n\n}",
+            "Body (/): \(formattedJson(for: response.data!))"
         ]
         
         Logging.isEnabled = true
@@ -110,20 +103,13 @@ struct APIClientTests {
     )
     func client_fails_onValidEmptyResponse_withFailureStatusCode(_ response: TestResponse) async throws {
 
-        let expectedLogs: [MockDebugLogger.Log] = [
-            .init("---- Request (/) ----"),
-            .init("---- Request base url (/) ----"),
-            .init("https://www.adyen.com/"),
-            .init("---- Request Headers (/) ----"),
-            .init("{\n\n}"),
-            .init("---- Request query (/) ----"),
-            .init("{\n\n}"),
-            .init("---- Response Code (/) ----"),
-            .init("\(response.response!.statusCode)"),
-            .init("---- Response Headers (/) ----"),
-            .init("{\n\n}"),
-            .init("---- Response (/) ----"),
-            .init(formattedJson(for: response.data!))
+        let expectedLogs: [String] = [
+            "https://www.adyen.com//",
+            "Query (/): {\n\n}",
+            "Headers (/): {\n\n}",
+            "Status Code (/): \(response.response!.statusCode)",
+            "Headers (/): {\n\n}",
+            "Body (/): \(formattedJson(for: response.data!))"
         ]
         
         Logging.isEnabled = true
@@ -154,20 +140,13 @@ struct APIClientTests {
         
         let expectedResponse = MockResponse(someField: "SomeValue")
         
-        let expectedLogs: [MockDebugLogger.Log] = [
-            .init("---- Request (/) ----"),
-            .init("---- Request base url (/) ----"),
-            .init("https://www.adyen.com/"),
-            .init("---- Request Headers (/) ----"),
-            .init("{\n  \"HeaderName\" : \"HeaderValue\"\n}"),
-            .init("---- Request query (/) ----"),
-            .init("{\n  \"name\" : \"value\"\n}"),
-            .init("---- Response Code (/) ----"),
-            .init("200"),
-            .init("---- Response Headers (/) ----"),
-            .init("{\n\n}"),
-            .init("---- Response (/) ----"),
-            .init("{\n  \"someField\" : \"SomeValue\"\n}")
+        let expectedLogs: [String] = [
+            "https://www.adyen.com//",
+            "Query (/): {\n  \"name\" : \"value\"\n}",
+            "Headers (/): {\n  \"HeaderName\" : \"HeaderValue\"\n}",
+            "Status Code (/): 200",
+            "Headers (/): {\n\n}",
+            "Body (/): {\n  \"someField\" : \"SomeValue\"\n}"
         ]
         
         Logging.isEnabled = true
@@ -206,7 +185,7 @@ private extension APIClientTests {
     func perform<RequestType: Request>(
         request: RequestType,
         testResponse: TestResponse,
-        debugLogger: any DebugLogging = MockDebugLogger()
+        debugLogger: MockDebugLogger = MockDebugLogger()
     ) async -> Result<RequestType.ResponseType, Error> {
         await withCheckedContinuation { continuation in
             let mockURLSession = MockURLSession(
@@ -218,7 +197,7 @@ private extension APIClientTests {
             APIClient(
                 apiContext: MockAPIContext(),
                 urlSession: mockURLSession,
-                debugLogger: debugLogger
+                logger: { _ in debugLogger }
             ).perform(request) { result in
                 continuation.resume(returning: result)
             }

--- a/Tests/UnitTests/Mocks/MockDebugLogger.swift
+++ b/Tests/UnitTests/Mocks/MockDebugLogger.swift
@@ -9,20 +9,10 @@
 
 class MockDebugLogger: DebugLogging {
     
-    struct Log: Equatable {
-        let content: String
-        let fileId: String
-        
-        init(_ content: String, fileId: String = "AdyenNetworking/APIClient.swift") {
-            self.content = content
-            self.fileId = fileId
-        }
-    }
+    var logs: [String] = []
     
-    var logs: [Log] = []
-    
-    func print(_ items: Any..., separator: String, terminator: String, fileId: String) {
+    func print(_ message: () -> String) {
         guard Logging.isEnabled else { return }
-        logs += items.map { .init("\($0)", fileId: fileId) }
+        logs.append(message())
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
1. Introduced two OSLog categories -- request and response -- so logs can be filtered independently in Console.app
2. Reformatted log output to follow a consistent Label (/path): value pattern, making it easier to correlate entries from concurrent requests
3. Added @autoclosure to avoid evaluating log messages when logging is disabled
4. Replaced the single logger property with a (LogCategory) -> any DebugLogging closure for cleaner dependency injection
5. Updated adyenPrintAsJSON to support an optional label for better context at call sites

###CI/CD fixes:

1. Bumped Xcode to latest in the CocoaPods workflow to resolve simulator destination resolution failure on macos-15

## Tested scenarios
<!-- Description of tested scenarios -->


https://github.com/user-attachments/assets/87267fbb-856a-4bd2-b18b-e5368e8aa275

**Fixed issue**:  <!-- #-prefixed issue number -->
