### PR TITLE
FIX the prepare release issue that podspec didn't update version

### DIFF
--- a/AdyenNetworking.podspec
+++ b/AdyenNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'AdyenNetworking'
-  s.version = '3.0.1'
+  s.version = '3.1.0'
   s.summary = "Adyen Networking for iOS"
   s.description = <<-DESC
     Adyen Networking for iOS provides Http/Https networking API's.

--- a/Scripts/increment_version.sh
+++ b/Scripts/increment_version.sh
@@ -15,7 +15,9 @@ then
   agvtool new-marketing-version $NEW_VERSION
   agvtool new-version -all $NEW_VERSION
 
-  sed -i '' -e "s/$CURRENT_VERSION/$NEW_VERSION/" $PODSPEC_PATH
+  # Replace the podspec version regardless of its current value, so the bump
+  # does not depend on the Xcode marketing version matching the podspec.
+  sed -i '' -E "s/(s\.version[[:space:]]*=[[:space:]]*)'[^']*'/\1'$NEW_VERSION'/" $PODSPEC_PATH
 fi
 
 CURRENT_VERSION=`agvtool mvers -terse1`


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

As you can see from https://github.com/Adyen/adyen-networking-ios/pull/68#issue-4797359027 the fix made CI to put an MR with right version bump include podspec

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
